### PR TITLE
Strip out CR from CRLF line endings in uploadScript

### DIFF
--- a/lib/bluetooth.dart
+++ b/lib/bluetooth.dart
@@ -183,6 +183,7 @@ class BrilliantDevice {
       String file = await rootBundle.loadString(filePath);
 
       file = file.replaceAll('\\', '\\\\');
+      file = file.replaceAll("\r\n", "\\n");
       file = file.replaceAll("\n", "\\n");
       file = file.replaceAll("'", "\\'");
       file = file.replaceAll('"', '\\"');


### PR DESCRIPTION
Lua scripts sent to Frame via uploadScript() in bluetooth.dart fail if they contain any (or all) CRLF line endings, and the control character escaping in this function presently doesn't handle them. 
This change causes CR characters to be stripped out of the script and all files are handled as though they only have LF line endings.