### PR TITLE
bump to ladybug

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,15 +31,15 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace "xyz.brilliant.noaflutter"
     compileSdk flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    ndkVersion "25.1.8937393"
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,8 @@
+#Sun Oct 13 01:39:48 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version '8.3.2' apply false
+    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
The code present on the repo doesn't build using the latest android studio & friends. Since I don't do much android development, I grabbed the latest I could of:
Android Studio == 2024.2.1
Gradle == 8.10.2
Java / JDK == Adoptium OpenJDK 21.0.4+7

With these, we apparently need to make some changes to the gradle configs to actually use flutter.
The best synopsis of these changes can be found on the flutter issue: https://github.com/flutter/flutter/issues/156304

The app appears to compile and run just fine, though there are deprecation warnings for packages that will be incompatible with gradle (?) 9
```
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings
```
